### PR TITLE
Add support for HDMI CEC by providing cec-{on,off}.sh in home-dir

### DIFF
--- a/docs/image-setup.sh
+++ b/docs/image-setup.sh
@@ -142,7 +142,7 @@ ssh "sudo rm /etc/profile.d/sshpwd.sh"
 ssh "echo | sudo tee /etc/motd"
 
 working "Installing packages"
-ssh "sudo apt-get update && sudo apt-get install -y vim matchbox-window-manager unclutter mailutils nitrogen jq chromium-browser xserver-xorg xinit rpd-plym-splash xdotool"
+ssh "sudo apt-get update && sudo apt-get install -y vim matchbox-window-manager unclutter mailutils nitrogen jq chromium-browser xserver-xorg xinit rpd-plym-splash xdotool cec-utils"
 # We install mailutils just so that you can check "mail" for cronjob output
 
 working "Setting home directory default content"

--- a/home/cec-off.sh
+++ b/home/cec-off.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'standby 0' | cec-client -s > /dev/null

--- a/home/cec-on.sh
+++ b/home/cec-on.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'on 0' | cec-client -s > /dev/null

--- a/home/crontab.example
+++ b/home/crontab.example
@@ -14,6 +14,7 @@ DISPLAY=:0.0
 0 3 * * * sudo reboot
 
 # Example: Turn display on weekdays at 7 AM
+# Note: You may exchange "display-on" / "display-off" with "cec-on" / "cec-off" in order to use HDMI CEC
 # 0 7 * * 1-5 ~/display-on.sh
 
 # Example: Turn display off weekdays at 7 PM (and after the nightly reboot)


### PR DESCRIPTION
Using CEC may add support for better power saving (sending the monitor to standby instead of rendering "waiting for devices"). This commit adds separate cec-scripts, installs the necessary package and provides a note in the crontab