### PR TITLE
Set URL before boot #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,18 @@ Easy-to-use **Raspberry Pi** image for booting directly into **full-screen Chrom
 2. Download the [latest image](https://github.com/futurice/chilipie-kiosk/releases).
 3. Decompress it.
 4. Flash the image onto your SD card. We recommend [Etcher](https://etcher.io/) for this: it's delightfully easy to use, cross platform, and will verify the result automatically. If you know what you're doing, you can of course also just `sudo dd bs=1m if=chilipie-kiosk-vX.Y.Z.img of=/dev/rdisk2`.
-5. *Optional*: [Setup automatic WiFi](#automatic-wifi-setup)
-6. Insert the SD card to your Pi and power it up.
-7. You should land in the [first-boot document](docs/first-boot.md), for further instructions & ideas.
+5. *Optional*: [Set URL before boot](#set-url-before-boot)
+6. *Optional*: [Setup automatic WiFi](#automatic-wifi-setup)
+7. Insert the SD card to your Pi and power it up.
+8. You should land in the [first-boot document](docs/first-boot.md), for further instructions & ideas.
+
+### Set URL before boot
+
+1. After flashing remount your SD card.
+2. Create a *chilipie_url.txt* in your SD cards boot folder or */home/pi*.
+3. Write URL in **first** line of file.
+
+Note: You can user `${SERIAL}` to get Pi's serial number into URL.  
 
 ### Automatic WiFi setup
 

--- a/home/.xsession
+++ b/home/.xsession
@@ -28,10 +28,22 @@ fi
 # Remove notes of previous sessions, if any
 find .config/chromium/ -name "Last *" | xargs rm
 
+# Get URL from file (if set)
+URL=""
+if [ -f /boot/chilipie_url.txt ]; then
+    URL="$(head -n 1 /boot/chilipie_url.txt)"
+elif [ -f /home/pi/chilipie_url.txt ]; then
+    URL="$(head -n 1 /home/pi/chilipie_url.txt)"
+fi
+if [ -n "$URL" ]; then
+    SERIAL="$(cat /proc/cpuinfo | grep Serial | cut -d ' ' -f 2 | xargs)" # Get serial number
+    URL="$(echo $URL | SERIAL=$SERIAL envsubst '$SERIAL')"
+fi
+
 # Start and detach Chromium
 # http://peter.sh/experiments/chromium-command-line-switches/
 # Note that under matchbox, starting in full-screen without a window size doesn't behave well when you try to exit full screen (see https://unix.stackexchange.com/q/273989)
-chromium-browser --start-fullscreen --window-size=1920,1080 --disable-infobars &
+chromium-browser --start-fullscreen --window-size=1920,1080 --disable-infobars $URL &
 
 # Hide Chromium while it's starting/loading the page
 wid=`xdotool search --sync --onlyvisible --class chromium`


### PR DESCRIPTION
Added feature, so URL can be set before booting RPi by configuring `/boot/chilipie_url.txt` or `/home/pi/chilipie_url.txt`. RPi's *serial number* can also be included in URL.